### PR TITLE
joda time dependency removed from core since 3.2

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -33,7 +33,6 @@ The core of ScalikeJDBC has so few dependencies that you won't be bothered by de
 
 - JDBC Drivers you need
 - Commons DBCP
-- Joda Time 2.x
 - SLF4J API
 
 Of course, you can use c3p0 (or others) instead of commons-dbcp though ConnectionPool implementation for that isn't provided by default.


### PR DESCRIPTION
https://github.com/scalikejdbc/scalikejdbc/commit/c72a5d9eeae5cd5c5d99